### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/approveops.yml
+++ b/.github/workflows/approveops.yml
@@ -1,4 +1,5 @@
 name: ApproveOps
+permissions: {}
 on:
   issue_comment:
     types: [created, edited]


### PR DESCRIPTION
Potential fix for [https://github.com/joshjohanning-org/contexts-testing/security/code-scanning/9](https://github.com/joshjohanning-org/contexts-testing/security/code-scanning/9)

The proper fix is to add a `permissions:` block at the top level of the workflow file (`.github/workflows/approveops.yml`), directly under `name:` and above `on:`. This permissions block will set the default token permissions for all jobs in the workflow. If you want to start with the most restrictive settings (as CodeQL suggests), use an empty mapping: `permissions: {}`. It's a good idea to analyze which jobs require which permissions, and then explicitly grant them only what they need (e.g., `contents: read`, `issues: write`), but as the minimal required fix for this CodeQL complaint, introducing the block (even empty) suffices and does not break existing functionality.  
You should insert:

```yaml
permissions: {}
```

...between the `name:` and the `on:` blocks (i.e., after line 1).

If, in the future, any job or workflow step requires more than minimal permissions, you can update the mapping to e.g.,

```yaml
permissions:
  contents: read
  issues: write
```

But for now, the minimal fix is the explicit block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
