### PR TITLE
chore: rename secret PRIVATE_KEY to APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/approveops.yml
+++ b/.github/workflows/approveops.yml
@@ -19,7 +19,7 @@ jobs:
       id: app-token
       with:
         client-id: 170284
-        private-key: ${{ secrets.PRIVATE_KEY }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: ApproveOps - Approvals in IssueOps
       uses: joshjohanning/approveops@v3
@@ -35,7 +35,7 @@ jobs:
       #   id: get_installation_token
       #   with:
       #     app_id: 170284
-      #     private_key: ${{ secrets.PRIVATE_KEY }}
+      #     private_key: ${{ secrets.APP_PRIVATE_KEY }}
           
       # - id: check-approval
       #   name: check if there is an approve command from authorized party


### PR DESCRIPTION
## Summary

Renames secret references from `secrets.PRIVATE_KEY` to `secrets.APP_PRIVATE_KEY` for consistency across all repos.

### ⚠️ Before Merging
1. Create a new secret `APP_PRIVATE_KEY` with the same value as `PRIVATE_KEY`
2. Then merge this PR
3. Delete the old `PRIVATE_KEY` secret